### PR TITLE
5.0->5.2 kernels have no cpus_mask yet, 5.3 and up do. 

### DIFF
--- a/root/usr/src/iomemory-vsl4-4.3.7/kcpu.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kcpu.c
@@ -125,7 +125,12 @@ int kfio_create_kthread_on_cpu(fusion_kthread_func_t func, void *data,
 
 static void __kfio_bind_task_to_cpumask(struct task_struct *tsk, cpumask_t *mask)
 {
+
+#if KFIOC_X_TASK_HAS_CPUS_MASK
     tsk->cpus_mask = *mask;
+#else
+    tsk->cpus_allowed = *mask;
+#endif
     tsk->nr_cpus_allowed = cpumask_weight(mask);
 }
 

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio_config_add.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio_config_add.sh
@@ -12,6 +12,7 @@ TEST_RATE=$(expr $NCPUS "*" 2)
 KFIOC_TEST_LIST="${KFIOC_TEST_LIST}
 KFIOC_X_HAS_COARSE_REAL_TS
 KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS
+KFIOC_X_TASK_HAS_CPUS_MASK
 "
 
 KFIOC_REMOVE_TESTS=""
@@ -59,6 +60,24 @@ start_tests()
     # We want more time for ourselves than the child tests
     TIMEOUT_DELTA=$(($TIMEOUT_DELTA+$TIMEOUT_DELTA/2))
     update_timeout
+}
+
+# flag:          KFIOC_X_TASK_HAS_CPUS_MASK
+# usage:         1   Task struct has CPUs allowed as mask 5.2 and up
+#                0   5.0, 5.1 and 5.2 don't have this
+KFIOC_X_TASK_HAS_CPUS_MASK()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/sched.h>
+void kfioc_check_task_has_cpus_mask(void)
+{
+    cpumask_t *cpu_mask = NULL;
+    struct task_struct *tsk = NULL;
+    tsk->cpus_mask = *cpu_mask;
+}
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror
 }
 
 # flag:           KFIOC_X_REQUEST_QUEUE_HAS_SPECIAL


### PR DESCRIPTION
We check if the struct has it, otherwise we move to cpus_allowed which is the old way of assigning masks.