### PR TITLE
Dkms vsl install

### DIFF
--- a/root/usr/src/iomemory-vsl4-4.3.7/kcpu.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kcpu.c
@@ -125,7 +125,6 @@ int kfio_create_kthread_on_cpu(fusion_kthread_func_t func, void *data,
 
 static void __kfio_bind_task_to_cpumask(struct task_struct *tsk, cpumask_t *mask)
 {
-
 #if KFIOC_X_TASK_HAS_CPUS_MASK
     tsk->cpus_mask = *mask;
 #else

--- a/root/usr/src/iomemory-vsl4-4.3.7/license.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/license.c
@@ -1,3 +1,3 @@
 #include "linux/module.h"
 MODULE_LICENSE("GPL");
-MODULE_VERSION("v5.6.0-22-ge9c4c00-4.3.7");
+MODULE_VERSION("v5.6.1-1-g4c68d83-4.3.7");

--- a/root/usr/src/iomemory-vsl4-4.3.7/module_operations.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/module_operations.sh
@@ -7,7 +7,7 @@ set -e
 
 dkms_ver() {
     name=$1
-    ver=$(dkms status | grep $name | grep -v added | cut -d, -f2 | sed -e s/\ //)
+    ver=$(dkms status | grep "$name " | grep -v added | cut -d, -f2 | sed -e s/\ //)
     if [ "$?" != "0" ]; then
         echo "DKMS problem"
         exit 1

--- a/root/usr/src/iomemory-vsl4-4.3.7/module_operations.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/module_operations.sh
@@ -128,6 +128,14 @@ sanity_check() {
     fi
 }
 
+install_libvsl() {
+    target_dir="/usr/lib/fio"
+    mkdir -p $target_dir
+    src_dir=$(git rev-parse --show-toplevel)
+    libvsl=$(find ${src_dir}/root/usr/lib/fio -type f| grep libvsl)
+    cp $libvsl $target_dir
+}
+
 usage() {
     echo "${0##*/}:
   -n <module name>
@@ -211,4 +219,5 @@ elif [ "$DKMS" == "1" ]; then
         patchFile $DKMS_DIR/kfio/$LIB $RELEASE_VER $MODULE_VER
     done
     dkms_install $MODULE_NAME $RELEASE_VER
+    install_libvsl $MODULE_NAME
 fi


### PR DESCRIPTION
Installs the libvsl_4 library in /usr/bin/fio, fio-utils will not work without it, and the rpm + deb install it by default.