### PR TITLE
Fix several make options and no gpl flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ dkms: clean
 		$(MAKE) dkms
 
 .PHONY: dpkg
-dpkg: clean
+dpkg: clean patch_module_version
 	# patch fio_version, fio_short_version in debian/fio_values
 	cd $(shell git rev-parse --show-toplevel) && \
 		dpkg-buildpackage -rfakeroot --no-check-builddeps --no-sign
 
 .PHONY: rpm
-rpm: clean
+rpm: clean patch_module_version
 	#	patch fio_version in fio-driver.spec
 	mkdir -p ~/rpmbuild/SOURCES && \
 	tar -zcvf ~/rpmbuild/SOURCES/iomemory-vsl4-4.3.7.1205.tar.gz \
@@ -29,6 +29,11 @@ module: clean
 clean:
 	cd root/usr/src/$(shell ls root/usr/src) && \
   	$(MAKE) clean
+
+patch_module_version:
+	cd root/usr/src/$(shell ls root/usr/src) && \
+		$(MAKE) patch_module_version
+
 
 define usage
 @echo Stub for making dkms, dpkg, the module and clean

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Package: iomemory-vsl4-di-5.3.0-45-generic
 Package-Type: udeb
 Architecture: amd64
 Depends:
-XB-Kernel-Version: 5.3.0-45-generic 5.3.0-45-generic 5.3.0-45-generic 5.3.0-45-generic 5.3.0-45-generic 5.3.0-45-generic 5.3.0-45-generic 5.3.0-45-generic 5.3.0-42-generic 5.3.0-42-generic
+XB-Kernel-Version: 5.3.0-45-generic
 Section: debian-installer
 Description: Source to build driver for SanDisk Fusion ioMemory devices
  Source to build driver for SanDisk Fusion ioMemory devices

--- a/debian/iomemory-vsl4-source.install
+++ b/debian/iomemory-vsl4-source.install
@@ -142,7 +142,6 @@ usr/src/iomemory-vsl4-4.3.7/kcondvar.c
 usr/src/iomemory-vsl4-4.3.7/module_param.c
 usr/src/iomemory-vsl4-4.3.7/cdev.c
 usr/src/iomemory-vsl4-4.3.7/Makefile
-usr/src/iomemory-vsl4-4.3.7/kfio_config_add.sh
 usr/src/iomemory-vsl4-4.3.7/kscsi_host.c
 usr/src/iomemory-vsl4-4.3.7/kscsi.c
 usr/src/iomemory-vsl4-4.3.7/license.c

--- a/debian/rules
+++ b/debian/rules
@@ -76,7 +76,7 @@ debian/control: FORCE
 		cp "$$file" "$$new_file"; \
 	done
 	# Add the kernel version to our UEFI Ubuntu driver injection disk
-	sed -r -i -e 's/^XB-Kernel-Version:/XB-Kernel-Version: $(deb_kernel_version)/;' $@
+	sed -r -i -e 's/^XB-Kernel-Version:.*/XB-Kernel-Version: $(deb_kernel_version)/;' $@
 	cp -r $(CURDIR)/debian/$(fio_driver_name).postinst "$(CURDIR)/debian/$(fio_driver_name)-$(deb_kernel_version).postinst"
 	echo depmod $(deb_kernel_version) >> "$(CURDIR)/debian/$(fio_driver_name)-$(deb_kernel_version).postinst"
 	cp -r $(CURDIR)/debian/$(fio_driver_name).postrm "$(CURDIR)/debian/$(fio_driver_name)-$(deb_kernel_version).postrm"

--- a/fio-driver.spec
+++ b/fio-driver.spec
@@ -261,7 +261,6 @@ Source to build driver for SanDisk Fusion ioMemory devices
 /usr/src/iomemory-vsl4-4.3.7/state.c
 /usr/src/iomemory-vsl4-4.3.7/sysrq.c
 /usr/src/iomemory-vsl4-4.3.7/*.conf
-/usr/src/iomemory-vsl4-4.3.7/kfio_config_add.sh
 /usr/src/iomemory-vsl4-4.3.7/module_operations.sh
 /usr/src/iomemory-vsl4-4.3.7/kfio/*
 /usr/src/iomemory-vsl4-4.3.7/include/fio/port/arch/ppc/atomic.h

--- a/root/usr/src/iomemory-vsl4-4.3.7/Makefile
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Makefile
@@ -88,7 +88,7 @@ clean modules_clean:
 		EXTRA_CFLAGS+="$(CFLAGS)" \
 		KFIO_LIB=$(KFIO_LIB) \
 		clean
-	rm -rf include/fio/port/linux/kfio_config.h kfio_config
+	rm -rf include/fio/port/linux/kfio_config.h kfio_config license.c
 
 include/fio/port/linux/kfio_config.h: kfio_config.sh
 	./$< -a $(FIOARCH) -o $@ -k $(KERNEL_BUILD) -p -d $(CURDIR)/kfio_config -l $(FUSION_DEBUG) -s $(KERNEL_SRC)

--- a/root/usr/src/iomemory-vsl4-4.3.7/Makefile
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Makefile
@@ -62,7 +62,7 @@ LAST_KFIO_LIB := $(shell ls -1 kfio | sort | tail -1)
 
 NCPUS:=$(shell grep -c ^processor /proc/cpuinfo)
 
-all: modules patch_module_version
+all: fake_license modules patch_module_version
 
 gpl: fake_license modules patch_module_version
 

--- a/root/usr/src/iomemory-vsl4-4.3.7/Makefile
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Makefile
@@ -88,7 +88,7 @@ clean modules_clean:
 		EXTRA_CFLAGS+="$(CFLAGS)" \
 		KFIO_LIB=$(KFIO_LIB) \
 		clean
-	rm -rf include/fio/port/linux/kfio_config.h kfio_config license.c
+	rm -rf include/fio/port/linux/kfio_config.h kfio_config
 
 include/fio/port/linux/kfio_config.h: kfio_config.sh
 	./$< -a $(FIOARCH) -o $@ -k $(KERNEL_BUILD) -p -d $(CURDIR)/kfio_config -l $(FUSION_DEBUG) -s $(KERNEL_SRC)

--- a/root/usr/src/iomemory-vsl4-4.3.7/Makefile
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Makefile
@@ -88,7 +88,7 @@ clean modules_clean:
 		EXTRA_CFLAGS+="$(CFLAGS)" \
 		KFIO_LIB=$(KFIO_LIB) \
 		clean
-	rm -rf include/fio/port/linux/kfio_config.h kfio_config
+	rm -rf include/fio/port/linux/kfio_config.h kfio_config license.c
 
 include/fio/port/linux/kfio_config.h: kfio_config.sh
 	./$< -a $(FIOARCH) -o $@ -k $(KERNEL_BUILD) -p -d $(CURDIR)/kfio_config -l $(FUSION_DEBUG) -s $(KERNEL_SRC)
@@ -121,7 +121,13 @@ dkms:
 dpkg:
 	# patch fio_version, fio_short_version in debian/fio_values
 	cd $(shell git rev-parse --show-toplevel) && \
-		dpkg-buildpackage -rfakeroot --no-check-builddeps --no-sign
+			$(MAKE) dpkg
+
+.PHONY: dpkg
+rpm:
+		# patch fio_version, fio_short_version in debian/fio_values
+		cd $(shell git rev-parse --show-toplevel) && \
+			$(MAKE) rpm
 
 modules modules_install: check_n_fix_kfio_ccver check_target_kernel include/fio/port/linux/kfio_config.h add_module_version
 	$(MAKE) \

--- a/root/usr/src/iomemory-vsl4-4.3.7/dkms.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/dkms.conf
@@ -1,4 +1,4 @@
-MAKE="'make' gpl DKMS_KERNEL_VERSION=$kernelver"
+MAKE="'make' DKMS_KERNEL_VERSION=$kernelver"
 CLEAN="'make' clean"
 BUILT_MODULE_NAME=iomemory-vsl4
 BUILT_MODULE_LOCATION=''

--- a/root/usr/src/iomemory-vsl4-4.3.7/module_operations.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/module_operations.sh
@@ -112,6 +112,7 @@ patchLicenseVersion() {
     tag=$1
     src=license.c
     echo "Adding module version $tag to source $src"
+    set +e
     grep -q MODULE_VERSION $src
     if [ "$?" == "0" ]; then
         replace=$(perl -sne 'print "s/$2/$tag/\n" if /(MODULE_VERSION)\(\"([\d\w\._-]+)\"\)/' -- -tag=$tag $src | head -1)
@@ -119,6 +120,7 @@ patchLicenseVersion() {
     else
         echo "MODULE_VERSION(\""$tag"\");" >> $src
     fi
+    set -e
 }
 
 sanity_check() {

--- a/root/usr/src/iomemory-vsl4-4.3.7/module_operations.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/module_operations.sh
@@ -118,6 +118,8 @@ patchLicenseVersion() {
         replace=$(perl -sne 'print "s/$2/$tag/\n" if /(MODULE_VERSION)\(\"([\d\w\._-]+)\"\)/' -- -tag=$tag $src | head -1)
         sed -i "$replace" $src
     else
+        echo "#include \"linux/module.h\"" > $src
+        echo "MODULE_LICENSE(\"GPL\");" >> $src
         echo "MODULE_VERSION(\""$tag"\");" >> $src
     fi
     set -e


### PR DESCRIPTION
fixes several packaging and make issues found. Not clearing out the license.c file is a good idea for srouce rpm, and source deb package building. The generation of the license file happens from the dirver root on dkms and on module build. The no GPL flag is just a nuisance, and the driver doesn't work without it, might as well make it the default.