### PR TITLE
v5.9.0 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+FIO_DRIVER = $(shell grep fio_driver_name fio-driver.spec | awk '{print $$3}' | head -1)
+FIO_VERSION = $(shell grep fio_version fio-driver.spec | awk '{print $$3}' | head -1)
+
 all: help
 
 .PHONY: dkms
@@ -15,9 +18,9 @@ dpkg: clean patch_module_version
 rpm: clean patch_module_version
 	#	patch fio_version in fio-driver.spec
 	mkdir -p ~/rpmbuild/SOURCES && \
-	tar -zcvf ~/rpmbuild/SOURCES/iomemory-vsl4-4.3.7.1205.tar.gz \
-		--transform s/iomemory-vsl4/iomemory-vsl4-4.3.7.1205/ \
-		../iomemory-vsl4 && \
+	tar -zcvf ~/rpmbuild/SOURCES/${FIO_DRIVER}-${FIO_VERSION}.tar.gz \
+		--transform s/${FIO_DRIVER}/${FIO_DRIVER}-${FIO_VERSION}/ \
+		../${FIO_DRIVER} && \
 	cd $(shell git rev-parse --show-toplevel) && \
 			rpmbuild -ba fio-driver.spec
 

--- a/root/usr/src/iomemory-vsl4-4.3.7/Kbuild
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Kbuild
@@ -9,7 +9,7 @@ endif
 
 
 $(src)/license.c: $(src)/Kbuild
-	printf '#include "linux/module.h"\nMODULE_LICENSE("Proprietary");\n' >$@
+	printf '#include "linux/module.h"\nMODULE_LICENSE("GPL");\n' >$@
 
 
 obj-m := $(FIO_DRIVER_NAME).o

--- a/root/usr/src/iomemory-vsl4-4.3.7/Makefile
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Makefile
@@ -35,8 +35,7 @@ KERNEL_SRC = /lib/modules/$(KERNELVER)/source
 
 # Set PORT_NO_WERROR=0 to compile without -Werror compilation flag
 ifneq ($(PORT_NO_WERROR),1)
-# We don't want the -Wvla errors for now
-#   CFLAGS += -Werror
+#    CFLAGS += -Werror
 endif
 
 # Set FUSION_DEBUG=0 to compile without debugging symbols
@@ -58,7 +57,8 @@ MODULE_VERSION ?= $(shell git rev-parse --short HEAD)
 TARGET ?= $(FIOARCH)_cc$(CCMAJOR)$(CCMINOR)
 
 KFIO_LIB ?= kfio/$(TARGET)_libkfio.o_shipped
-LAST_KFIO_LIB := $(shell ls -1 kfio | sort | tail -1)
+LAST_KFIO_LIB := $(shell ls -1 kfio | grep $(LAST_CCVER) | sort | tail -1)
+KFIO_LIB_CMD ?= kfio/.$(TARGET)_libkfio.o.cmd
 
 NCPUS:=$(shell grep -c ^processor /proc/cpuinfo)
 
@@ -77,6 +77,7 @@ check_n_fix_kfio_ccver:
 			cp kfio/${LAST_KFIO_LIB} ${KFIO_LIB}; \
 		fi \
 	fi
+	$(shell touch ${KFIO_LIB_CMD})
 
 clean modules_clean:
 	$(MAKE) \
@@ -129,7 +130,7 @@ rpm:
 		cd $(shell git rev-parse --show-toplevel) && \
 			$(MAKE) rpm
 
-modules modules_install: check_n_fix_kfio_ccver check_target_kernel include/fio/port/linux/kfio_config.h add_module_version
+modules modules_install: check_target_kernel check_n_fix_kfio_ccver include/fio/port/linux/kfio_config.h add_module_version
 	$(MAKE) \
     -j$(NCPUS) \
 	-C $(KERNEL_BUILD) \

--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.3.0-45-generic"
-PREV_KERNEL_SRC="/lib/modules/5.3.0-45-generic/build"
+PREV_KERNELVER="5.4.0-59-generic"
+PREV_KERNEL_SRC="/lib/modules/5.4.0-59-generic/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.4.0-59-generic"
-PREV_KERNEL_SRC="/lib/modules/5.4.0-59-generic/build"
+PREV_KERNELVER="5.9.6"
+PREV_KERNEL_SRC="/lib/modules/5.9.6/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -1,0 +1,31 @@
+/*
+  This "meta" file is supposed to abstract things that change in kblock.c
+  and should provide simplified defines that are named after their function.
+  Both aimed at making the code cleaner, more readable and perhaps more
+  maintainable. Blocks should be isolated and only cover one item.
+ */
+#ifndef __FIO_KBLOCK_META_H__
+#define __FIO_KBLOCK_META_H__
+
+#if KFIOC_X_LINUX_HAS_PART_STAT_H
+#include <linux/part_stat.h>
+#endif /* KFIOC_X_LINUX_HAS_PART_STAT_H */
+
+#if KFIOC_X_HAS_MAKE_REQUEST_FN
+  static unsigned int kfio_make_request(struct request_queue *queue, struct bio *bio);
+  #define BLK_QUEUE_SPLIT blk_queue_split(queue, &bio);
+
+  #if KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
+    #define BLK_ALLOC_QUEUE blk_alloc_queue_node(GFP_NOIO, node);
+  #else /* KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS */
+    #define BLK_ALLOC_QUEUE blk_alloc_queue(kfio_make_request, node);
+  #endif /* KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS */
+
+#else /* KFIOC_X_HAS_MAKE_REQUEST_FN */
+  blk_qc_t kfio_submit_bio(struct bio *bio);
+
+  #define BLK_ALLOC_QUEUE blk_alloc_queue(node);
+  #define BLK_QUEUE_SPLIT blk_queue_split(&bio);
+#endif /* KFIOC_X_HAS_MAKE_REQUEST_FN */
+
+#endif /* __FIO_KBLOCK_META_H__ */

--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -241,14 +241,13 @@ static struct block_device_operations fio_bdev_ops =
     .open =         kfio_open,
     .release =      kfio_release,
     .ioctl =        kfio_ioctl,
-    .compat_ioctl = kfio_compat_ioctl
+    .compat_ioctl = kfio_compat_ioctl,
 #if ! KFIOC_X_HAS_MAKE_REQUEST_FN
-    .submit_bio =   kfio_submit_bio,
+    .submit_bio =   kfio_submit_bio
 #endif
 };
 
 static struct request_queue *kfio_alloc_queue(struct kfio_disk *dp, kfio_numa_node_t node);
-static unsigned int kfio_make_request(struct request_queue *queue, struct bio *bio);
 static void __kfio_bio_complete(struct bio *bio, uint32_t bytes_complete, int error);
 
 static inline void kfio_set_comp_cpu(struct kfio_bio* fbio, struct bio* bio)
@@ -1600,7 +1599,7 @@ static struct request_queue *kfio_alloc_queue(struct kfio_disk *dp,
 
     test_safe_plugging(); // not sure if this is needed now.
 
-    rq = blk_alloc_queue_node(GFP_NOIO, node);
+    rq = BLK_ALLOC_QUEUE;
     if (rq != NULL)
     {
         rq->queuedata = dp;

--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -53,11 +53,9 @@
 #include <fio/port/cdev.h>
 #include <linux/buffer_head.h>
 #include <linux/blk-mq.h>
+#include <kblock_meta.h>
 
-
-extern int use_workqueue;
-static int fio_major;
-
+/* should these not be in a header file? */
 static void linux_bdev_name_disk(struct fio_bdev *bdev);
 static int  linux_bdev_create_disk(struct fio_bdev *bdev);
 static int  linux_bdev_expose_disk(struct fio_bdev *bdev);
@@ -68,10 +66,12 @@ static void linux_bdev_lock_pending(struct fio_bdev *bdev, int pending);
 static void linux_bdev_update_stats(struct fio_bdev *bdev, int dir, uint64_t totalsize, uint64_t duration);
 static void linux_bdev_update_inflight(struct fio_bdev *bdev, int rw, int in_flight);
 
+extern int use_workqueue;
+static int fio_major;
+
 #define BI_SIZE(bio) (bio->bi_iter.bi_size)
 #define BI_SECTOR(bio) (bio->bi_iter.bi_sector)
 #define BI_IDX(bio) (bio->bi_iter.bi_idx)
-
 
 /******************************************************************************
  *   Block request and bio processing methods.                                *
@@ -99,7 +99,9 @@ struct kfio_disk
     struct list_head      retry_list;
     unsigned int          retry_cnt;
     fusion_atomic32_t     ref_count;
+#if KFIOC_X_HAS_MAKE_REQUEST_FN
     make_request_fn      *make_request_fn;
+#endif
     int                   use_workqueue;
     struct blk_mq_tag_set tag_set;
 };
@@ -121,7 +123,6 @@ extern int enable_discard;
 #define bio_flags(bio) ((bio)->bi_opf & REQ_OP_MASK)
 
 extern int kfio_sgl_map_bio(kfio_sg_list_t *sgl, struct bio *bio);
-
 
 /******************************************************************************
  *   Functions required to register and unregister fio block device driver    *
@@ -241,6 +242,9 @@ static struct block_device_operations fio_bdev_ops =
     .release =      kfio_release,
     .ioctl =        kfio_ioctl,
     .compat_ioctl = kfio_compat_ioctl
+#if ! KFIOC_X_HAS_MAKE_REQUEST_FN
+    .submit_bio =   kfio_submit_bio,
+#endif
 };
 
 static struct request_queue *kfio_alloc_queue(struct kfio_disk *dp, kfio_numa_node_t node);
@@ -1600,8 +1604,9 @@ static struct request_queue *kfio_alloc_queue(struct kfio_disk *dp,
     if (rq != NULL)
     {
         rq->queuedata = dp;
+#if KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
         blk_queue_make_request(rq, kfio_make_request);
-
+#endif
         // TODO:
         // if kfio_disk support spinlock_t instead of lame fusion_spinlock_t for queueu_lock
         // dp->queue_lock = rq->queue_lock;
@@ -1779,9 +1784,16 @@ static struct bio *kfio_add_bio_to_plugged_list(void *data, struct bio *bio)
     return ret;
 }
 
+#if KFIOC_X_HAS_MAKE_REQUEST_FN
 static unsigned int kfio_make_request(struct request_queue *queue, struct bio *bio)
+#else
+blk_qc_t kfio_submit_bio(struct bio *bio)
+#endif
 #define FIO_MFN_RET 0
 {
+#if ! KFIOC_X_HAS_MAKE_REQUEST_FN
+    struct request_queue *queue = bio->bi_disk->queue;
+#endif
     struct kfio_disk *disk = queue->queuedata;
     void *plug_data;
 
@@ -1796,7 +1808,7 @@ static unsigned int kfio_make_request(struct request_queue *queue, struct bio *b
     //   and re-submit the remainder to the request queue. blk_queue_split() does all that for us.
     // It appears the kernel quit honoring the blk_queue_max_segments() in about 4.13.
     if (bio_segments(bio) >= queue_max_segments(queue))
-        blk_queue_split(queue, &bio);
+      BLK_QUEUE_SPLIT;
 
     /*
      * The atomic chains have more overhead (using atomic contexts etc) so

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
@@ -75,6 +75,9 @@ KFIOC_TEST_LIST="
 KFIOC_X_HAS_COARSE_REAL_TS
 KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS
 KFIOC_X_TASK_HAS_CPUS_MASK
+KFIOC_X_LINUX_HAS_PART_STAT_H
+KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
+KFIOC_X_HAS_MAKE_REQUEST_FN
 "
 
 
@@ -94,6 +97,70 @@ done
 #
 # Actual test procedures for determining Kernel capabilities
 #
+##
+## Newly added tests HAVE to contain the kernel version it appeared in and an
+## LWN reference where the change in the kernel is and some form of reference
+## to documentation describing the change in the kernel.
+##
+####
+# flag:            KFIOC_X_HAS_MAKE_REQUEST_FN
+# usage:           1   Kernels that do have blk_alloc_queue_node
+#                  0   Kernels that don't have blk_alloc_queue_node
+# kernel_version:  In 5.9 make_request_fn got removed and we move to bio_submit
+KFIOC_X_HAS_MAKE_REQUEST_FN()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/blkdev.h>
+void kfioc_has_make_request_fn(void)
+{
+  struct kfio_disk
+  {
+      make_request_fn       *make_request_fn;
+  };
+}
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror
+}
+
+# flag:            KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
+# usage:           1   Kernels that do have blk_alloc_queue_node
+#                  0   Kernels that don't have blk_alloc_queue_node
+# kernel_version:  In 5.7 blk_alloc_queue node got removed, which simplifies things
+KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/blkdev.h>
+void kfioc_check_blk_alloc_queue_node(void)
+{
+  struct request_queue *rq;
+  int node = 1;
+
+  rq = blk_alloc_queue_node(GFP_NOIO, node);
+}
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror
+}
+
+# flag:            KFIOC_X_LINUX_HAS_PART_STAT_H
+# usage:           1   Kernels that have linux/part_stats.h
+#                  0   No kernel before 5.7 has linux/part_stat.h
+# kernel_version:  Partition statistics got their own header file in 5.7 and
+#                  onwards
+KFIOC_X_LINUX_HAS_PART_STAT_H()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/part_stat.h>
+void kfioc_check_linux_has_part_stats_h(void)
+{
+    part_stat_lock();
+}
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror
+}
+
 ####
 # flag:          KFIOC_X_TASK_HAS_CPUS_MASK
 # usage:         1   Task struct has CPUs allowed as mask 5.2 and up

--- a/root/usr/src/iomemory-vsl4-4.3.7/kscatter.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kscatter.c
@@ -260,14 +260,8 @@ int kfio_sgl_map_bytes_gen(kfio_sg_list_t *sgl, const void *buffer, uint32_t siz
         else
         {
             int retval;
-
-            // XXX Do we need to widen the interface to allow non-writable here?
             retval = get_user_pages_fast((uintptr_t)bp, 1, GET_USER_PAGES_FLAGS(1, 0), (struct page **) &page);
 
-            /* down_read(&current->mm->mmap_sem);
-            retval = get_user_pages((uintptr_t)bp, 1, GET_USER_PAGES_FLAGS(1, 0), (struct page **)&page, NULL);
-            up_read(&current->mm->mmap_sem);
-            */
             if (retval <= 0)
             {
                 // Release the pages that worked up until now and return the error.

--- a/root/usr/src/iomemory-vsl4-4.3.7/kscatter.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kscatter.c
@@ -262,9 +262,12 @@ int kfio_sgl_map_bytes_gen(kfio_sg_list_t *sgl, const void *buffer, uint32_t siz
             int retval;
 
             // XXX Do we need to widen the interface to allow non-writable here?
-            down_read(&current->mm->mmap_sem);
+            retval = get_user_pages_fast((uintptr_t)bp, 1, GET_USER_PAGES_FLAGS(1, 0), (struct page **) &page);
+
+            /* down_read(&current->mm->mmap_sem);
             retval = get_user_pages((uintptr_t)bp, 1, GET_USER_PAGES_FLAGS(1, 0), (struct page **)&page, NULL);
             up_read(&current->mm->mmap_sem);
+            */
             if (retval <= 0)
             {
                 // Release the pages that worked up until now and return the error.

--- a/root/usr/src/iomemory-vsl4-4.3.7/pci.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/pci.c
@@ -770,7 +770,7 @@ struct pci_device_id iodrive_ids[] = {
 
 
 static pci_ers_result_t
-iodrive_pci_error_detected (struct pci_dev *dev, enum pci_channel_state error)
+iodrive_pci_error_detected (struct pci_dev *dev, pci_channel_state_t error)
 {
     errprint_lbl(pci_name(dev), ERRID_CMN_LINUX_PCI_ERR, "iodrive: PCI Error detected: %d\n", error);
     return PCI_ERS_RESULT_DISCONNECT;

--- a/tools/udev/rules.d/60-persistent-fio.rules
+++ b/tools/udev/rules.d/60-persistent-fio.rules
@@ -1,0 +1,28 @@
+# persistent storage links for iomemory-vsl devices.
+# requires fio-status in /usr/bin.
+
+ACTION=="remove", GOTO="persistent_fio_end"
+ENV{UDEV_DISABLE_PERSISTENT_STORAGE_RULES_FLAG}=="1", GOTO="persistent_fio_end"
+
+SUBSYSTEM!="block", GOTO="persistent_fio_end"
+KERNEL!="fio*", GOTO="persistent_fio_end"
+
+# this was copied over from 60-persistent-storage, I believe it tries to see
+# if /sys/block/fio*/whole_disk merely exists
+TEST=="whole_disk", GOTO="persistent_fio_end"
+
+# partition handling also originates there.
+ENV{DEVTYPE}=="partition", \
+  IMPORT{parent}="ID_[!F]*", IMPORT{parent}="ID_", \
+  IMPORT{parent}="ID_F[!S]*", IMPORT{parent}="ID_F", \
+  IMPORT{parent}="ID_FS[!_]*", IMPORT{parent}="ID_FS"
+
+# by-id
+KERNEL=="fio[a-z]", PROGRAM="/usr/bin/fio-status --field iom.format_uuid /dev/%k", SYMLINK+="disk/by-id/fio-%c"
+KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/usr/bin/fio-status --field iom.format_uuid /dev/%P", SYMLINK+="disk/by-id/fio-%c-part%n"
+
+# by-path
+KERNEL=="fio[a-z]", PROGRAM="/usr/bin/fio-status --field iom.pci_addr /dev/%k", SYMLINK+="disk/by-path/pci-0000:%c-%k"
+KERNEL=="fio[a-z][0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/usr/bin/fio-status --field iom.pci_addr /dev/%P", SYMLINK+="disk/by-path/pci-0000:%c-%P-part%n"
+
+LABEL="persistent_fio_end"


### PR DESCRIPTION
* sync makefiles and kfio_config.sh with iomemory-vsl
* Move to get_user_pages_fast
* introduce kblock_meta.h to keep code more 
* defines replacing unreadable ifdefs for BLK_ALLOC_QUEUE and BLK_QUEUE_SPLIT
* new udev rules from iomemory-vsl
* fix block_device_operations
* replace enum for pci_channel_state to pci_channel_state_t