### PR TITLE
5.11 support

### DIFF
--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.9.6"
-PREV_KERNEL_SRC="/lib/modules/5.9.6/build"
+PREV_KERNELVER="5.8.0-44-generic"
+PREV_KERNEL_SRC="/lib/modules/5.8.0-44-generic/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.8.0-44-generic"
-PREV_KERNEL_SRC="/lib/modules/5.8.0-44-generic/build"
+PREV_KERNELVER="5.11.0-16-generic"
+PREV_KERNEL_SRC="/lib/modules/5.11.0-16-generic/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -27,5 +27,11 @@
   #define BLK_ALLOC_QUEUE blk_alloc_queue(node);
   #define BLK_QUEUE_SPLIT blk_queue_split(&bio);
 #endif /* KFIOC_X_HAS_MAKE_REQUEST_FN */
-
+#if KFIOC_X_GENHD_PART0_IS_A_POINTER
+  #define GD_PART0 gd->part0
+  #define GET_BDEV disk->gd->part0
+#else /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
+  #define GD_PART0 &gd->part0
+  #define GET_BDEV bdget_disk(disk->gd, 0)
+#endif /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
 #endif /* __FIO_KBLOCK_META_H__ */

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -29,7 +29,7 @@
 #endif /* KFIOC_X_HAS_MAKE_REQUEST_FN */
 #if KFIOC_X_GENHD_PART0_IS_A_POINTER
   #define GD_PART0 gd->part0
-  #define GET_BDEV disk->gd->part0
+  #define GET_BDEV bdgrab(disk->gd->part0)
 #else /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
   #define GD_PART0 &gd->part0
   #define GET_BDEV bdget_disk(disk->gd, 0)

--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -805,7 +805,7 @@ static int linux_bdev_hide_disk(struct fio_bdev *bdev, uint32_t opflags)
 
     if (disk->gd != NULL)
     {
-        linux_bdev = bdget_disk(disk->gd, 0);
+        linux_bdev = GET_BDEV;
 
         if (linux_bdev != NULL)
         {
@@ -957,18 +957,18 @@ void linux_bdev_update_stats(struct fio_bdev *bdev, int dir, uint64_t totalsize,
     case BIO_DIR_WRITE:
     {
         part_stat_lock();
-        part_stat_inc(&gd->part0, ios[1]);
-        part_stat_add(&gd->part0, sectors[1], totalsize >> 9);
-        part_stat_add(&gd->part0, nsecs[1], kfio_div64_64(duration * HZ, FIO_USEC_PER_SEC));
+        part_stat_inc(GD_PART0, ios[1]);
+        part_stat_add(GD_PART0, sectors[1], totalsize >> 9);
+        part_stat_add(GD_PART0, nsecs[1], kfio_div64_64(duration * HZ, FIO_USEC_PER_SEC));
         part_stat_unlock();
         break;
     }
     case BIO_DIR_READ:
     {
         part_stat_lock();
-        part_stat_inc(&gd->part0, ios[0]);
-        part_stat_add(&gd->part0, sectors[0], totalsize >> 9);
-        part_stat_add(&gd->part0, nsecs[0], kfio_div64_64(duration * HZ, FIO_USEC_PER_SEC));
+        part_stat_inc(GD_PART0, ios[0]);
+        part_stat_add(GD_PART0, sectors[0], totalsize >> 9);
+        part_stat_add(GD_PART0, nsecs[0], kfio_div64_64(duration * HZ, FIO_USEC_PER_SEC));
         part_stat_unlock();
         break;
     }
@@ -991,7 +991,7 @@ void linux_bdev_update_inflight(struct fio_bdev *bdev, int rw, int in_flight)
 
     if (disk->use_workqueue != USE_QUEUE_RQ && disk->use_workqueue != USE_QUEUE_MQ)
     {
-        part_stat_set_all(&gd->part0, in_flight);
+        part_stat_set_all(GD_PART0, in_flight);
     }
 }
 

--- a/root/usr/src/iomemory-vsl4-4.3.7/ktime.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/ktime.c
@@ -101,7 +101,9 @@ uint64_t noinline fusion_HZ(void)
  */
 uint32_t noinline kfio_get_seconds(void)
 {
-    return get_seconds();
+    // this hurts...till we can patch the binary .so we just do this
+    // means we are toast in 2038 though....
+    return (uint32_t) ktime_get_real_seconds();
 }
 
 /**

--- a/root/usr/src/iomemory-vsl4-4.3.7/module_operations.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/module_operations.sh
@@ -36,6 +36,7 @@ dkms_install() {
 
 get_rel_ver() {
     version=$1
+    kname=$(uname -r)
     release=$(git describe --tag)
     if [ "$version" == "" ]; then
         tag=$(git rev-parse --short HEAD)
@@ -43,10 +44,10 @@ get_rel_ver() {
     if [ "$version" == "" -a "$release" == "" ]; then
         echo "Error: not a release and no git tag, aborting."
         exit 1
+    elif [ "$version" != "" ]; then
+        echo ${kname%-*}-${version}
     elif [ "$release" != "" ]; then
         echo $release
-    elif [ "$version" != "" ]; then
-        echo $version
     else
         echo "deadbeef"
     fi


### PR DESCRIPTION
* In 5.11 the gendisk part becomes a pointer and also a block_device, which causes two changes in the code. These are reflected by two defines in block_meta.h.
* Make sure we can build on sshfs, move the fifo to /tmp
* Move to timekeeping.h instead of time.h. Main snag here is that we are limited to 32bits due to the libkfio.h at the moment. This has to move to 64 bits before 2038.
* Adding kernel name to version