### PR TITLE
pulling to 5.12

### DIFF
--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -11,6 +11,12 @@
 #include <linux/part_stat.h>
 #endif /* KFIOC_X_LINUX_HAS_PART_STAT_H */
 
+#if KFIOC_X_BIO_HAS_BI_BDEV
+  #define BIO_DISK bi_bdev->bd_disk
+#else /* KFIOC_X_BIO_HAS_BI_BDEV */
+  #define BIO_DISK bi_disk
+#endif /* KFIOC_X_BIO_HAS_BI_BDEV */
+
 #if KFIOC_X_HAS_MAKE_REQUEST_FN
   static unsigned int kfio_make_request(struct request_queue *queue, struct bio *bio);
   #define BLK_QUEUE_SPLIT blk_queue_split(queue, &bio);

--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -1791,7 +1791,7 @@ blk_qc_t kfio_submit_bio(struct bio *bio)
 #define FIO_MFN_RET 0
 {
 #if ! KFIOC_X_HAS_MAKE_REQUEST_FN
-    struct request_queue *queue = bio->bi_disk->queue;
+    struct request_queue *queue = bio->BIO_DISK->queue;
 #endif
     struct kfio_disk *disk = queue->queuedata;
     void *plug_data;

--- a/root/usr/src/iomemory-vsl4-4.3.7/ktime.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/ktime.c
@@ -125,14 +125,8 @@ uint64_t noinline fusion_getmicrotime(void)
 /// @brief return current UTC wall clock time in seconds since the Unix epoch (Jan 1 1970).
 uint64_t noinline fusion_getwallclocktime(void)
 {
-#if KFIOC_X_HAS_COARSE_REAL_TS
     struct timespec64 ts;
-
     ktime_get_coarse_real_ts64(&ts);
-#else
-    struct timespec ts = current_kernel_time();
-#endif
-
     return (uint64_t)ts.tv_sec;
 }
 


### PR DESCRIPTION
Add KFIOC_X_BIO_HAS_BI_BDEV for bio mvonig bi_disk to bi_bdev->bd_disk
Remove KFIOC_X_HAS_COARSE_REAL_TS which left the building in 4.18-ish