### PR TITLE
Fix the stats to not throw random large numbers anymore. 

### DIFF
--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -991,7 +991,6 @@ void linux_bdev_update_inflight(struct fio_bdev *bdev, int rw, int in_flight)
 
     if (disk->use_workqueue != USE_QUEUE_RQ && disk->use_workqueue != USE_QUEUE_MQ)
     {
-        part_stat_set_all(GD_PART0, in_flight);
     }
 }
 


### PR DESCRIPTION
Seems like I broke this a long time ago by mistaken stats for in_flights. The in_flight handling seems to have moved into the kernel a longer time ago, so we're making these empty. Also inline with what we have in VSL