### PR TITLE
pick the kblock_meta.h from vsl to fix BLK_ALLOC_QUEUE error

### DIFF
--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.11.0-31-generic"
-PREV_KERNEL_SRC="/lib/modules/5.11.0-31-generic/build"
+PREV_KERNELVER="5.13.0-23-generic"
+PREV_KERNEL_SRC="/lib/modules/5.13.0-23-generic/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -23,6 +23,8 @@
 
   #if KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
     #define BLK_ALLOC_QUEUE blk_alloc_queue_node(GFP_NOIO, node);
+  #elif KFIOC_X_BLK_ALLOC_QUEUE_EXISTS
+    #define BLK_ALLOC_QUEUE blk_alloc_queue(GFP_NOIO);
   #else /* KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS */
     #define BLK_ALLOC_QUEUE blk_alloc_queue(kfio_make_request, node);
   #endif /* KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS */

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
@@ -305,7 +305,7 @@ update_timeout()
 # while still having stdout and stderr sent to . . . stdout and stderr!
 open_log()
 {
-    FIFO_DIR=$CONFIGDIR
+    FIFO_DIR=${FIFO_DIR:=$CONFIGDIR}
     # FIFO_DIR=/tmp
     # The tee processes will die when this process exits.
     rm -f "$FIFO_DIR/kfio_config.stdout" "$FIFO_DIR/kfio_config.stderr" "$FIFO_DIR/kfio_config.log"


### PR DESCRIPTION
Sync the kblock_meta.h between vsl and vsl4, they should actually always be in sync...