### PR TITLE
Fixes 5.16 and prior

### DIFF
--- a/root/usr/src/iomemory-vsl4-4.3.7/Makefile
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Makefile
@@ -91,7 +91,6 @@ clean modules_clean:
 		EXTRA_CFLAGS+="$(CFLAGS)" \
 		KFIO_LIB=$(KFIO_LIB) \
 		clean
-	rm -rf include/fio/port/linux/kfio_config.h kfio_config license.c
 
 include/fio/port/linux/kfio_config.h: kfio_config.sh
 	./$< -a $(FIOARCH) -o $@ -k $(KERNEL_BUILD) -p -d $(CURDIR)/kfio_config -l $(FUSION_DEBUG) -s $(KERNEL_SRC)

--- a/root/usr/src/iomemory-vsl4-4.3.7/Makefile
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Makefile
@@ -91,6 +91,7 @@ clean modules_clean:
 		EXTRA_CFLAGS+="$(CFLAGS)" \
 		KFIO_LIB=$(KFIO_LIB) \
 		clean
+	rm -rf include/fio/port/linux/kfio_config.h kfio_config
 
 include/fio/port/linux/kfio_config.h: kfio_config.sh
 	./$< -a $(FIOARCH) -o $@ -k $(KERNEL_BUILD) -p -d $(CURDIR)/kfio_config -l $(FUSION_DEBUG) -s $(KERNEL_SRC)

--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.13.0-37-generic"
-PREV_KERNEL_SRC="/lib/modules/5.13.0-37-generic/build"
+PREV_KERNELVER="5.13.0-39-generic"
+PREV_KERNEL_SRC="/lib/modules/5.13.0-39-generic/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.13.0-39-generic"
-PREV_KERNEL_SRC="/lib/modules/5.13.0-39-generic/build"
+PREV_KERNELVER="5.8.0-63-generic"
+PREV_KERNEL_SRC="/lib/modules/5.8.0-63-generic/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -56,7 +56,7 @@
   #define BLK_QUEUE_SPLIT blk_queue_split(&bio);
 #endif /* KFIOC_X_HAS_MAKE_REQUEST_FN */
 
-
+// should check for hd_struct vs gendisk
 #if KFIOC_X_GENHD_PART0_IS_A_POINTER
   #define GD_PART0 disk->gd->part0
   #define GET_BDEV disk->gd->part0

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -7,9 +7,11 @@
 #ifndef __FIO_KBLOCK_META_H__
 #define __FIO_KBLOCK_META_H__
 
+
 #if KFIOC_X_LINUX_HAS_PART_STAT_H
 #include <linux/part_stat.h>
 #endif /* KFIOC_X_LINUX_HAS_PART_STAT_H */
+
 
 #if KFIOC_X_BLK_ALLOC_DISK_EXISTS
   #define BLK_ALLOC_QUEUE dp->gd->queue;
@@ -21,22 +23,24 @@
   #define BLK_ALLOC_DISK alloc_disk
 #endif
 
+
 #if KFIOC_X_BIO_HAS_BI_BDEV
   #define BIO_DISK bi_bdev->bd_disk
 #else /* KFIOC_X_BIO_HAS_BI_BDEV */
   #define BIO_DISK bi_disk
 #endif /* KFIOC_X_BIO_HAS_BI_BDEV */
 
+
 #if KFIOC_X_HAS_MAKE_REQUEST_FN
   static unsigned int kfio_make_request(struct request_queue *queue, struct bio *bio);
   #define KFIO_SUBMIT_BIO_RC return FIO_MFN_RET;
-
   #define BLK_QUEUE_SPLIT blk_queue_split(queue, &bio);
+
   #if KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
     #define BLK_ALLOC_QUEUE blk_alloc_queue_node(GFP_NOIO, node);
   #elif KFIOC_X_BLK_ALLOC_QUEUE_EXISTS
     #define BLK_ALLOC_QUEUE blk_alloc_queue(GFP_NOIO);
-  #else /* KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS */
+  #else
     #define BLK_ALLOC_QUEUE blk_alloc_queue(kfio_make_request, node);
   #endif /* KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS */
 
@@ -49,9 +53,10 @@
     #define KFIO_SUBMIT_BIO_RC
   #endif
   KFIO_SUBMIT_BIO;
-
   #define BLK_QUEUE_SPLIT blk_queue_split(&bio);
 #endif /* KFIOC_X_HAS_MAKE_REQUEST_FN */
+
+
 #if KFIOC_X_GENHD_PART0_IS_A_POINTER
   #define GD_PART0 gd->part0
   #define GET_BDEV disk->gd->part0
@@ -60,11 +65,13 @@
   #define GET_BDEV bdgrab(disk->gd->part0);
 #endif /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
 
+
 #if KFIOC_X_VOID_ADD_DISK
 #define ADD_DISK add_disk(disk->gd);
 #else
 #define ADD_DISK if (add_disk(disk->gd)) { infprint("Error while adding disk!"); }
 #endif
+
 
 #if KFIOC_X_DISK_HAS_OPEN_MUTEX
 #define SHUTDOWN_MUTEX &disk->gd->open_mutex

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -61,8 +61,8 @@
   #define GD_PART0 disk->gd->part0
   #define GET_BDEV disk->gd->part0
 #else /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
-  #define GD_PART0 &gd->part0
-  #define GET_BDEV bdgrab(disk->gd->part0);
+  #define GD_PART0 &disk->gd->part0
+  #define GET_BDEV bdget_disk(disk->gd, 0);
 #endif /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
 
 

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -54,10 +54,10 @@
 #endif /* KFIOC_X_HAS_MAKE_REQUEST_FN */
 #if KFIOC_X_GENHD_PART0_IS_A_POINTER
   #define GD_PART0 gd->part0
-  #define GET_BDEV bdgrab(disk->gd->part0);
+  #define GET_BDEV disk->gd->part0
 #else /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
   #define GD_PART0 &gd->part0
-  #define GET_BDEV disk->gd->part0
+  #define GET_BDEV bdgrab(disk->gd->part0);
 #endif /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
 
 #if KFIOC_X_VOID_ADD_DISK
@@ -66,5 +66,10 @@
 #define ADD_DISK if (add_disk(disk->gd)) { infprint("Error while adding disk!"); }
 #endif
 
+#if KFIOC_X_DISK_HAS_OPEN_MUTEX
+#define SHUTDOWN_MUTEX &disk->gd->open_mutex
+#else
+#define SHUTDOWN_MUTEX &linux_bdev->bd_mutex
+#endif
 
 #endif /* __FIO_KBLOCK_META_H__ */

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -58,7 +58,7 @@
 
 
 #if KFIOC_X_GENHD_PART0_IS_A_POINTER
-  #define GD_PART0 gd->part0
+  #define GD_PART0 disk->gd->part0
   #define GET_BDEV disk->gd->part0
 #else /* KFIOC_X_GENHD_PART0_IS_A_POINTER */
   #define GD_PART0 &gd->part0

--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -953,7 +953,6 @@ static void linux_bdev_destroy_disk(struct fio_bdev *bdev)
 void linux_bdev_update_stats(struct fio_bdev *bdev, int dir, uint64_t totalsize, uint64_t duration)
 {
     struct kfio_disk *disk = (struct kfio_disk *)bdev->bdev_gd;
-    struct gendisk* gd = disk->gd;
 
     if (disk == NULL || disk->use_workqueue != USE_QUEUE_NONE)
     {

--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -651,7 +651,7 @@ static int linux_bdev_expose_disk(struct fio_bdev *bdev)
         return -ENODEV;
     }
 
-    disk->rq = NULL;
+    disk->gd = gd = BLK_ALLOC_DISK(FIO_NUM_MINORS);
 
     switch(use_workqueue)
     {
@@ -694,7 +694,7 @@ static int linux_bdev_expose_disk(struct fio_bdev *bdev)
             goto err; // this should not happen
     }
 
-    rq = disk->rq;
+    rq = disk->gd->queue;
 
     blk_limits_io_min(&rq->limits, bdev->bdev_block_size);
     blk_limits_io_opt(&rq->limits, fio_dev_optimal_blk_size);
@@ -718,7 +718,6 @@ static int linux_bdev_expose_disk(struct fio_bdev *bdev)
     /* Disable device global entropy contribution */
     blk_queue_flag_clear(QUEUE_FLAG_ADD_RANDOM, rq);
 
-    disk->gd = gd = BLK_ALLOC_DISK(FIO_NUM_MINORS);
     if (disk->gd == NULL)
     {
         linux_bdev_hide_disk(bdev, KFIO_DISK_OP_SHUTDOWN | KFIO_DISK_OP_FORCE);
@@ -810,7 +809,7 @@ static int linux_bdev_hide_disk(struct fio_bdev *bdev, uint32_t opflags)
 
     if (disk->gd != NULL)
     {
-	    linux_bdev = GET_BDEV;
+        linux_bdev = GET_BDEV;
 
         if (linux_bdev != NULL)
         {

--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -694,7 +694,11 @@ static int linux_bdev_expose_disk(struct fio_bdev *bdev)
             goto err; // this should not happen
     }
 
-    rq = disk->gd->queue;
+    if (disk->gd->queue) {
+      rq = disk->gd->queue;
+    } else {
+      rq = disk->rq;
+    }
 
     blk_limits_io_min(&rq->limits, bdev->bdev_block_size);
     blk_limits_io_opt(&rq->limits, fio_dev_optimal_blk_size);
@@ -985,19 +989,6 @@ void linux_bdev_update_stats(struct fio_bdev *bdev, int dir, uint64_t totalsize,
 
 void linux_bdev_update_inflight(struct fio_bdev *bdev, int rw, int in_flight)
 {
-    struct kfio_disk *disk = (struct kfio_disk *)bdev->bdev_gd;
-    struct gendisk *gd;
-
-    if (disk == NULL || disk->gd == NULL)
-    {
-        return;
-    }
-
-    gd = disk->gd;
-
-    if (disk->use_workqueue != USE_QUEUE_RQ && disk->use_workqueue != USE_QUEUE_MQ)
-    {
-    }
 }
 
 /**

--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -890,8 +890,8 @@ static int linux_bdev_hide_disk(struct fio_bdev *bdev, uint32_t opflags)
                  * here and no concurrent open-close operation can race with the
                  * wait below.
                  */
-                 mutex_lock(&linux_bdev->bd_mutex);
-                 mutex_unlock(&linux_bdev->bd_mutex);
+                 mutex_lock(SHUTDOWN_MUTEX);
+                 mutex_unlock(SHUTDOWN_MUTEX);
 
                  fusion_cv_lock_irq(&disk->state_lk);
                  while (linux_bdev->bd_openers > 0 && linux_bdev->bd_disk == disk->gd)

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
@@ -76,6 +76,7 @@ KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS
 KFIOC_X_TASK_HAS_CPUS_MASK
 KFIOC_X_LINUX_HAS_PART_STAT_H
 KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS
+KFIOC_X_BLK_ALLOC_QUEUE_EXISTS
 KFIOC_X_BLK_ALLOC_DISK_EXISTS
 KFIOC_X_HAS_MAKE_REQUEST_FN
 KFIOC_X_GENHD_PART0_IS_A_POINTER
@@ -257,7 +258,7 @@ void kfioc_has_make_request_fn(void)
 # usage:           1   Kernels that do have blk_alloc_queue_node
 #                  0   Kernels that don't have blk_alloc_queue_node
 # kernel_version:  In 5.7 blk_alloc_queue_node got removed and introduced block_alloc_queue,
- #                  which simplifies things
+ #                 which simplifies things
 KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS()
 {
     local test_flag="$1"
@@ -274,6 +275,25 @@ void kfioc_check_blk_alloc_queue_node(void)
     kfioc_test "$test_code" "$test_flag" 1 -Werror
 }
 
+# flag:            KFIOC_X_BLK_ALLOC_QUEUE_EXISTS
+# usage:           1   Kernels that do have blk_alloc_queue
+#                  0   Kernels that don't have blk_alloc_queue
+# kernel_version:  In 5.7 blk_alloc_queue node got removed and introduced block_alloc_queue,
+#                  which simplifies things
+KFIOC_X_BLK_ALLOC_QUEUE_EXISTS()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/blkdev.h>
+void kfioc_check_blk_alloc_queue(void)
+{
+  struct request_queue *rq;
+  int node = 1;
+  rq = blk_alloc_queue(node);
+}
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror
+}
 
 # flag:            KFIOC_X_LINUX_HAS_PART_STAT_H
 # usage:           1   Kernels that have linux/part_stats.h

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
@@ -82,6 +82,7 @@ KFIOC_X_GENHD_PART0_IS_A_POINTER
 KFIOC_X_BIO_HAS_BI_BDEV
 KFIOC_X_SUBMIT_BIO_RETURNS_BLK_QC_T
 KFIOC_X_VOID_ADD_DISK
+KFIOC_X_DISK_HAS_OPEN_MUTEX
 "
 
 
@@ -143,6 +144,28 @@ void kfioc_check_void_add_disk(void)
   add_disk(gd);
 }
 
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror
+}
+
+# flag:            KFIOC_X_DISK_HAS_OPEN_MUTEX
+# usage:           1   Kernels that have open_mutex on disks
+#                  0   Kernels that have bd_mutex on the bd
+# kernel_version:  In 5.14 introduces open_mutex on disks, and removes bd_mutex
+#                  from a block device
+# driver:          vsl4
+KFIOC_X_DISK_HAS_OPEN_MUTEX()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/blkdev.h>
+void kfioc_check_disk_open_mutex(void)
+{
+  struct gendisk *gd = NULL;
+  struct mutex open_mutex;
+
+  open_mutex = gd->open_mutex;
+}
 '
     kfioc_test "$test_code" "$test_flag" 1 -Werror
 }


### PR DESCRIPTION
1) Fix for 5.15, 5.16. Also tested with 5.13, 5.8.0 and 5.4.0. 
2) Fixes dpkg
3) reintroduces a check for BLK_ALLOC_QUEUE_EXISTS for earlier releases.
