### PR TITLE
#40 KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS failing

### DIFF
--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.8.0-63-generic"
-PREV_KERNEL_SRC="/lib/modules/5.8.0-63-generic/build"
+PREV_KERNELVER="5.4.17-2136.306.1.3.el7uek.x86_64"
+PREV_KERNEL_SRC="/lib/modules/5.4.17-2136.306.1.3.el7uek.x86_64/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="5.4.17-2136.306.1.3.el7uek.x86_64"
-PREV_KERNEL_SRC="/lib/modules/5.4.17-2136.306.1.3.el7uek.x86_64/build"
+PREV_KERNELVER="5.13.0-39-generic"
+PREV_KERNEL_SRC="/lib/modules/5.13.0-39-generic/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
@@ -349,7 +349,7 @@ KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS()
 
 void *kfioc_has_proc_create_data(struct inode *inode)
 {
-    const struct proc_ops *pops;
+    const struct proc_ops *pops = NULL;
     return proc_create_data(NULL, 0, NULL, pops, NULL);
 }
 '

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
@@ -353,7 +353,7 @@ void *kfioc_has_proc_create_data(struct inode *inode)
     return proc_create_data(NULL, 0, NULL, pops, NULL);
 }
 '
-    kfioc_test "$test_code" "$test_flag" 1 -Werror-implicit-function-declaration
+    kfioc_test "$test_code" "$test_flag" 1 "-Werror-implicit-function-declaration -Werror"
 }
 
 #


### PR DESCRIPTION
Fix KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS to return correctly when it fails, instead of silently failing.