### PR TITLE
iomemory-vsl bug#124 backport for 6.6 kernel

### DIFF
--- a/fio-driver.spec
+++ b/fio-driver.spec
@@ -264,6 +264,8 @@ Source to build driver for SanDisk Fusion ioMemory devices
 /usr/src/iomemory-vsl4-4.3.7/module_operations.sh
 /usr/src/iomemory-vsl4-4.3.7/kfio/*
 /usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+/usr/src/iomemory-vsl4-4.3.7/include/kfile_meta.h
+/usr/src/iomemory-vsl4-4.3.7/include/sysrq_meta.h
 /usr/src/iomemory-vsl4-4.3.7/include/fio/port/arch/ppc/atomic.h
 /usr/src/iomemory-vsl4-4.3.7/include/fio/port/arch/ppc/bits.h
 /usr/src/iomemory-vsl4-4.3.7/include/fio/port/arch/ppc/cache.h

--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="6.2.0-33-generic"
-PREV_KERNEL_SRC="/lib/modules/6.2.0-33-generic/build"
+PREV_KERNELVER="6.2.0-37-generic"
+PREV_KERNEL_SRC="/lib/modules/6.2.0-37-generic/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kfile_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kfile_meta.h
@@ -15,5 +15,5 @@
 #define KFIO_PDE_DATA pde_data(ip)
 #endif /* PDE_DATA */
 
-#endif /* __FIO_FILE_META_H__ */
+#endif /* __FIO_KFILE_META_H__ */
 

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/sysrq_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/sysrq_meta.h
@@ -1,0 +1,16 @@
+/*
+  This "meta" file is supposed to abstract things that change in sysrq.c
+  and should provide simplified defines that are named after their function.
+  Both aimed at making the code cleaner, more readable and perhaps more
+  maintainable. Blocks should be isolated and only cover one item.
+ */
+#ifndef __FIO_SYSRQ_META_H__
+#define __FIO_SYSRQ_META_H__
+
+#if KFIOC_X_HANDLE_SYSRQ_IS_U8
+#define HANDLE_SYSRQ_TYPE u8
+#else
+#define HANDLE_SYSRQ_TYPE int
+#endif /* KFIOC_X_HANDLE_SYSRQ_IS_U8 */
+
+#endif /* __FIO_SYSRQ_META_H__ */

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
@@ -72,6 +72,7 @@ EX_OSFILE=72
 # architecture.
 
 KFIOC_TEST_LIST="
+KFIOC_X_HANDLE_SYSRQ_IS_U8
 KFIOC_X_BDOPS_OPEN_GENDISK_AND_BLK_MODE_T
 KFIOC_X_BDOPS_RELEASE_1_ARG
 KFIOC_X_CAPS_PDE_DATA
@@ -112,6 +113,33 @@ done
 ## to documentation describing the change in the kernel.
 ##
 ####
+# flag:            KFIOC_X_HANDLE_SYSRQ_IS_U8
+# usage:           1   Kernels that use u8 or unsigned char for sysrq_handle
+#                  0   Kernels that use int for the above
+# kernel_version:  6.6
+KFIOC_X_HANDLE_SYSRQ_IS_U8()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/sysrq.h>
+
+void kfioc_check_handle_sysrq_is_u8(void)
+{
+    void t_handle_sysreq(u8 key) {};
+    struct sysrq_key_op t_key_op = {
+        .handler = t_handle_sysreq,
+        .help_msg = "ioDrive CSR (z)",
+        .action_msg = "ioDrive CSR status:",
+        .enable_mask = 0,
+    };
+    u8 key = 2;
+    register_sysrq_key(key, &t_key_op);
+    unregister_sysrq_key(key, &t_key_op);
+}
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror
+}
+
 # flag:            KFIOC_X_BDOPS_OPEN_GENDISK_AND_BLK_MODE_T
 # usage:           1   Kernels that pass gendisk and blk_mode_t to open for block_device_operations
 #                  0   Kernels that pass block_device and mode_t to open for block_device_operations

--- a/root/usr/src/iomemory-vsl4-4.3.7/sysrq.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/sysrq.c
@@ -33,6 +33,7 @@
 #include <fio/port/kfio_config.h>
 #include <fio/port/ktypes.h>
 #include <fio/port/dbgset.h>
+#include <sysrq_meta.h>
 
 /**
  * @ingroup PORT_COMMON_LINUX
@@ -45,7 +46,7 @@ extern void iodrive_dump_all_software_state(void);
 #define SYSRQ_SOFTWARE  'x'
 #define SYSRQ_CSR       'y'
 
-void iodrive_handle_sysrq(int key)
+void iodrive_handle_sysrq(HANDLE_SYSRQ_TYPE key)
 {
     switch (key)
     {


### PR DESCRIPTION
Backports iomemory-vsl commit [#125](https://github.com/RemixVSL/iomemory-vsl/commit/0c1e2536315fce80a4d19f6db541c50c504beea8)