### PR TITLE
Fix missing prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ gone through rigorous rewriting and cleaning of redundant, unused, and old code.
 This driver is aimed to support Linux kernels from 5.0 and upwards.
 
 ### Releases
-We've abandoned the notion of releases, Generally `main` should be checked out. `main` is completely backwards compatible for all **5**, and **6** kernels. The latest working tested kernel is **6.5**.
+We've abandoned the notion of releases, Generally `main` should be checked out. `main` is completely backwards compatible for all **5**, and **6** kernels. The latest working tested kernel is **6.8**.
 
 Historically releases were tagged, and were be checked out by their tag. The release tags follow Linux Kernel versions. E.g. **v5.12.1 (Boop Noodle)** will work on all 5.x kernels that are 5.12 and lower, but is not guaranteed to work on 5.13. **v4.20.2 - Big Ole Nope Rope** supports most kernels that pre-date 5.0. Again this way of following kernel releases has been abandoned. Please follow **main**.
 

--- a/root/usr/src/iomemory-vsl4-4.3.7/Makefile
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Makefile
@@ -35,9 +35,7 @@ KERNEL_SRC = /lib/modules/$(KERNELVER)/source
 
 # Set PORT_NO_WERROR=0 to compile without -Werror compilation flag
 ifneq ($(PORT_NO_WERROR),1)
-    ifeq ($(FIO_DRIVER_NAME), iomemory-vsl)
-        CFLAGS += -Werror
-    endif
+    CFLAGS += -Werror
 endif
 
 # Set FUSION_DEBUG=0 to compile without debugging symbols

--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="6.2.0-37-generic"
-PREV_KERNEL_SRC="/lib/modules/6.2.0-37-generic/build"
+PREV_KERNELVER="6.5.0-26-generic"
+PREV_KERNEL_SRC="/lib/modules/6.5.0-26-generic/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -32,7 +32,6 @@
 
 // Ignore this whole file, if the block device is not being included in the build.
 #if KFIO_BLOCK_DEVICE
-
 #include "port-internal.h"
 #include <fio/port/dbgset.h>
 #include <fio/port/kfio.h>
@@ -66,6 +65,14 @@ static void linux_bdev_backpressure(struct fio_bdev *bdev, int on);
 static void linux_bdev_lock_pending(struct fio_bdev *bdev, int pending);
 static void linux_bdev_update_stats(struct fio_bdev *bdev, int dir, uint64_t totalsize, uint64_t duration);
 static void linux_bdev_update_inflight(struct fio_bdev *bdev, int rw, int in_flight);
+int kfio_vectored_atomic(struct block_device *linux_bdev,
+                         const struct kfio_iovec *iov,
+                         uint32_t iovcnt,
+                         bool user_pages);
+int kfio_count_sectors_inuse(struct block_device *linux_bdev,
+                             uint64_t base,
+                             uint64_t length,
+                             uint64_t *count);
 
 extern int use_workqueue;
 static int fio_major;

--- a/root/usr/src/iomemory-vsl4-4.3.7/kcondvar.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kcondvar.c
@@ -36,6 +36,10 @@
 #include <fio/port/ktime.h>
 #include <linux/sched.h>    // for struct task_struct used in kassert
 
+int noinline __fusion_condvar_timedwait(fusion_condvar_t *cv,
+                                        fusion_cv_lock_t *lock,
+                                        int64_t timeout_us,
+                                        int interruptible);
 
 /**
  * @ingroup PORT_COMMON_LINUX

--- a/root/usr/src/iomemory-vsl4-4.3.7/kcsr.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kcsr.c
@@ -28,15 +28,16 @@
 #if defined(__KERNEL__)
 #include "port-internal.h"
 #include <asm/io.h>
-#else
-#include <fio/port/utypes.h>
-#include <fio/port/ufio.h>
 
-uint32_t kfio_csr_read_direct(volatile void *addr, void *hdl);
+uint32_t kfio_csr_read_direct(volatile void *addr, void *hdl);   
 uint64_t kfio_csr_read_direct_64(volatile void *addr, void *hdl);
 void kfio_csr_write_nobarrier(uint32_t val, volatile void *addr, void *hdl);
 void kfio_csr_write(uint32_t val, volatile void *addr, void *hdl);
 void kfio_csr_write_64(uint64_t val, volatile void *addr, void *hdl);
+
+#else /* not defined __KERNEL */
+#include <fio/port/utypes.h>
+#include <fio/port/ufio.h>
 
 /**
  * @ingroup PORT_COMMON_LINUX

--- a/root/usr/src/iomemory-vsl4-4.3.7/kcsr.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kcsr.c
@@ -32,6 +32,12 @@
 #include <fio/port/utypes.h>
 #include <fio/port/ufio.h>
 
+uint32_t kfio_csr_read_direct(volatile void *addr, void *hdl);
+uint64_t kfio_csr_read_direct_64(volatile void *addr, void *hdl);
+void kfio_csr_write_nobarrier(uint32_t val, volatile void *addr, void *hdl);
+void kfio_csr_write(uint32_t val, volatile void *addr, void *hdl);
+void kfio_csr_write_64(uint64_t val, volatile void *addr, void *hdl);
+
 /**
  * @ingroup PORT_COMMON_LINUX
  * @{

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio.c
@@ -40,6 +40,9 @@
 #include <fio/port/kfio_config.h>
 #include <linux/kallsyms.h>
 
+void noinline fusion_spin_lock_irq(fusion_spinlock_t *s);
+void noinline fusion_spin_unlock_irq(fusion_spinlock_t *s);
+
 /**
  * @ingroup PORT_LINUX
  * @{

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
@@ -123,6 +123,7 @@ KFIOC_X_HANDLE_SYSRQ_IS_U8()
     local test_code='
 #include <linux/sysrq.h>
 
+void kfioc_check_handle_sysrq_is_u8(void);
 void kfioc_check_handle_sysrq_is_u8(void)
 {
     void t_handle_sysreq(u8 key) {};
@@ -149,6 +150,7 @@ KFIOC_X_BDOPS_OPEN_GENDISK_AND_BLK_MODE_T()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_bdops_open_is_disk(void);
 void kfioc_check_bdops_open_is_disk(void)
 {
   struct block_device_operations *bops = NULL;
@@ -173,6 +175,7 @@ KFIOC_X_BDOPS_RELEASE_1_ARG()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_bdops(void);
 void kfioc_check_bdops(void)
 {
   struct block_device_operations *bops = NULL;
@@ -194,6 +197,7 @@ KFIOC_X_CAPS_PDE_DATA()
     local test_flag="$1"
     local test_code='
 #include <linux/proc_fs.h>
+void kfioc_check_caps_pde_data(void);
 void kfioc_check_caps_pde_data(void)
 {
   struct inode *i = NULL;
@@ -214,6 +218,7 @@ KFIOC_X_BIO_SPLIT_TO_LIMITS()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_bio_split_to_limits(void);
 void kfioc_check_bio_split_to_limits(void)
 {
   struct bio *bio = NULL;
@@ -233,6 +238,7 @@ KFIOC_X_SUBMIT_BIO_RETURNS_BLK_QC_T()
     local test_flag="$1"
     local test_code='
 #include <linux/bio.h>
+void kfioc_check_submit_bio_returns_blk_qc_t(void);
 void kfioc_check_submit_bio_returns_blk_qc_t(void)
 {
   struct bio *bio = NULL;
@@ -253,6 +259,7 @@ KFIOC_X_VOID_ADD_DISK()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_void_add_disk(void);
 void kfioc_check_void_add_disk(void)
 {
   struct gendisk *gd = NULL;
@@ -274,6 +281,7 @@ KFIOC_X_DISK_HAS_OPEN_MUTEX()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_disk_open_mutex(void);
 void kfioc_check_disk_open_mutex(void)
 {
   struct gendisk *gd = NULL;
@@ -295,6 +303,7 @@ KFIOC_X_BLK_ALLOC_DISK_EXISTS()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_blk_alloc_disk(void);
 void kfioc_check_blk_alloc_disk(void)
 {
   struct gendisk *gd;
@@ -317,6 +326,7 @@ KFIOC_X_BIO_HAS_BI_BDEV()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_bio_has_bi_bdev(void);
 void kfioc_bio_has_bi_bdev(void)
  {
   struct bio *bio = NULL;
@@ -339,6 +349,7 @@ KFIOC_X_GENHD_PART0_IS_A_POINTER()
     local test_code='
 #include <linux/blkdev.h>
 #include <linux/part_stat.h>
+void kfioc_genhd_part0_is_a_pointer(void);
 void kfioc_genhd_part0_is_a_pointer(void)
 {
   struct gendisk *gd = NULL;
@@ -357,6 +368,7 @@ KFIOC_X_HAS_MAKE_REQUEST_FN()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_has_make_request_fn(void);
 void kfioc_has_make_request_fn(void)
 {
   struct kfio_disk
@@ -378,6 +390,7 @@ KFIOC_X_BLK_ALLOC_QUEUE_NODE_EXISTS()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_blk_alloc_queue_node(void);
 void kfioc_check_blk_alloc_queue_node(void)
 {
   struct request_queue *rq;
@@ -399,6 +412,7 @@ KFIOC_X_BLK_ALLOC_QUEUE_EXISTS()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
+void kfioc_check_blk_alloc_queue(void);
 void kfioc_check_blk_alloc_queue(void)
 {
   struct request_queue *rq;
@@ -418,6 +432,7 @@ KFIOC_X_TASK_HAS_CPUS_MASK()
     local test_flag="$1"
     local test_code='
 #include <linux/sched.h>
+void kfioc_check_task_has_cpus_mask(void);
 void kfioc_check_task_has_cpus_mask(void)
 {
     cpumask_t *cpu_mask = NULL;
@@ -443,6 +458,7 @@ KFIOC_X_PROC_CREATE_DATA_WANTS_PROC_OPS()
     local test_code='
 #include <linux/proc_fs.h>
 
+void *kfioc_has_proc_create_data(struct inode *inode);
 void *kfioc_has_proc_create_data(struct inode *inode)
 {
     const struct proc_ops *pops = NULL;

--- a/root/usr/src/iomemory-vsl4-4.3.7/kinit.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kinit.c
@@ -41,6 +41,9 @@
 #include <fio/port/kscsi.h>
 #endif
 
+int kfio_platform_init_storage_interface(void);
+int kfio_platform_teardown_storage_interface(void);
+
 /**
  * @ingroup PORT_COMMON_LINUX
  * @{

--- a/root/usr/src/iomemory-vsl4-4.3.7/kscatter.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kscatter.c
@@ -34,6 +34,9 @@
 #include <fio/port/ktime.h>
 #include <linux/version.h>
 
+int kfio_sgl_map_bio(kfio_sg_list_t *sgl, struct bio *pbio);
+void *kfio_sgl_get_byte_pointer(kfio_sg_list_t *sgl, uint32_t offset);
+
 /**
  * @ingroup PORT_LINUX
  * @{

--- a/root/usr/src/iomemory-vsl4-4.3.7/pci.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/pci.c
@@ -41,6 +41,12 @@
 #include <fio/port/kpci.h>
 #include <fio/port/message_ids.h>
 
+irqreturn_t kfio_handle_irq_wrapper(int irq, void *dev_id);
+irqreturn_t kfio_hq_irq(int irq, void *dev_id);
+int iodrive_pci_probe(struct pci_dev *linux_pci_dev, const struct pci_device_id *id);
+int kfio_pci_register_driver(void);
+void kfio_pci_unregister_driver(void);
+
 /*************************************************************************************/
 /*   Legacy and MSI interrupts.                                                      */
 /*************************************************************************************/
@@ -48,7 +54,6 @@
  * @ingroup PORT_COMMON_LINUX
  * @{
  */
-
 irqreturn_t kfio_handle_irq_wrapper(int irq, void *dev_id)
 {
     (void)iodrive_intr_fast(irq, dev_id);

--- a/root/usr/src/iomemory-vsl4-4.3.7/sysrq.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/sysrq.c
@@ -35,6 +35,10 @@
 #include <fio/port/dbgset.h>
 #include <sysrq_meta.h>
 
+void iodrive_handle_sysrq(HANDLE_SYSRQ_TYPE key);
+void kfio_iodrive_sysrq_keys(void);
+void kfio_iodrive_unreg_sysrq_keys(void);
+
 /**
  * @ingroup PORT_COMMON_LINUX
  * @{


### PR DESCRIPTION
There were some prototypes missing for the tests and the driver. This commit adds the prototypes and turns on -Werror again, as it should be on.