### PR TITLE
6.15 and 6.14

### DIFF
--- a/root/usr/src/iomemory-vsl4-4.3.7/Kbuild
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Kbuild
@@ -17,6 +17,7 @@ obj-m := $(FIO_DRIVER_NAME).o
 $(FIO_DRIVER_NAME)-y := main.o
 $(FIO_DRIVER_NAME)-y += dbgset.o
 $(FIO_DRIVER_NAME)-y += license.o
+$(FIO_DRIVER_NAME)-y += mod.o
 $(FIO_DRIVER_NAME)-y += pci.o
 $(FIO_DRIVER_NAME)-y += sysrq.o
 $(FIO_DRIVER_NAME)-y += driver_init.o

--- a/root/usr/src/iomemory-vsl4-4.3.7/Makefile
+++ b/root/usr/src/iomemory-vsl4-4.3.7/Makefile
@@ -86,6 +86,7 @@ clean modules_clean:
 		FIO_DRIVER_NAME=$(FIO_DRIVER_NAME) \
 		FUSION_DRIVER_DIR=$(shell pwd) \
 		M=$(shell pwd) \
+		ccflags-y+="$(CFLAGS)" \
 		EXTRA_CFLAGS+="$(CFLAGS)" \
 		KFIO_LIB=$(KFIO_LIB) \
 		clean
@@ -138,9 +139,11 @@ modules modules_install: check_target_kernel check_n_fix_kfio_ccver include/fio/
 	FUSION_DRIVER_DIR=$(shell pwd) \
 	M=$(shell pwd) \
 	EXTRA_CFLAGS+="$(CFLAGS)" \
+	ccflags-y+="$(CFLAGS)" \
 	INSTALL_MOD_DIR=$(FIO_DRIVER_SUBDIR) \
 	INSTALL_MOD_PATH=$(INSTALL_ROOT) \
 	KFIO_LIB=$(KFIO_LIB) \
+	objtool=$(PWD)/objtool_wrapper \
 	$@
 
 endif

--- a/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
+++ b/root/usr/src/iomemory-vsl4-4.3.7/check_target_kernel.conf
@@ -1,2 +1,2 @@
-PREV_KERNELVER="6.8.0-52-generic"
-PREV_KERNEL_SRC="/lib/modules/6.8.0-52-generic/build"
+PREV_KERNELVER="6.8.0-62-generic"
+PREV_KERNEL_SRC="/lib/modules/6.8.0-62-generic/build"

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -17,6 +17,12 @@
 #include <linux/bio-integrity.h>
 #endif
 
+#if KFIOC_X_BLK_MQ_F_SHOULD_MERGE
+  #define SET_MQ_F_SHOULD_MERGE disk->tag_set.flags = BLK_MQ_F_SHOULD_MERGE;
+#else
+  #define SET_MQ_F_SHOULD_MERGE
+#endif
+
 #if KFIOC_X_BLK_ALLOC_DISK_EXISTS
   #define BLK_ALLOC_QUEUE dp->gd->queue;
   #define BLK_ALLOC_DISK blk_alloc_disk(FIO_NUM_MINORS);

--- a/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kblock.c
@@ -698,7 +698,7 @@ static int linux_bdev_expose_disk(struct fio_bdev *bdev)
             disk->tag_set.numa_node = bdev->bdev_numa_node;
             disk->tag_set.cmd_size = 0;
             disk->tag_set.driver_data = disk;
-            disk->tag_set.flags = BLK_MQ_F_SHOULD_MERGE;
+            SET_MQ_F_SHOULD_MERGE
             disk->tag_set.ops = &fio_mq_ops;
             // on NVME this is 32 - 2, the command size is the size of the struct they send
             // my guess is this is really inneficient?

--- a/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
+++ b/root/usr/src/iomemory-vsl4-4.3.7/kfio_config.sh
@@ -89,6 +89,7 @@ KFIOC_X_BIO_HAS_BI_BDEV
 KFIOC_X_SUBMIT_BIO_RETURNS_BLK_QC_T
 KFIOC_X_VOID_ADD_DISK
 KFIOC_X_DISK_HAS_OPEN_MUTEX
+KFIOC_X_BLK_MQ_F_SHOULD_MERGE
 "
 
 
@@ -114,6 +115,27 @@ done
 ## to documentation describing the change in the kernel.
 ##
 ####
+# flag:            KFIOC_X_BLK_MQ_F_SHOULD_MERGE
+# usage:           1   Kernels that have BLK_MQ_F_SHOULD_MERGE as an option
+#                  0   Kernels that don't have BLK_MQ_F_SHOULD_MERGE, and default to it
+# kernel_version:  6.14
+KFIOC_X_BLK_MQ_F_SHOULD_MERGE()
+{
+    local test_flag="$1"
+    local test_code='
+#include <linux/blkdev.h>
+#include <linux/blk-mq.h>
+void kfioc_blk_mq_f_should_merge(void);
+void kfioc_blk_mq_f_should_merge(void)
+{
+    struct blk_mq_tag_set tag_set;
+    tag_set.flags = BLK_MQ_F_SHOULD_MERGE;
+}
+
+'
+    kfioc_test "$test_code" "$test_flag" 1 -Werror
+}
+
 # flag:            KFIOC_X_BLK_ALLOC_DISK_HAS_QUEUE_LIMITS
 # usage:           1   Kernels where blk_alloc_disk has a queue_limits argument,
 #                      which implies it also haa blk_mq_alloc_disk.
@@ -285,11 +307,11 @@ KFIOC_X_VOID_ADD_DISK()
     local test_flag="$1"
     local test_code='
 #include <linux/blkdev.h>
-void kfioc_check_void_add_disk(void);
-void kfioc_check_void_add_disk(void)
+int kfioc_check_void_add_disk(void);
+int kfioc_check_void_add_disk(void)
 {
   struct gendisk *gd = NULL;
-  add_disk(gd);
+  return add_disk(gd)
 }
 
 '

--- a/root/usr/src/iomemory-vsl4-4.3.7/mod.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/mod.c
@@ -1,0 +1,5 @@
+#include <linux/module.h>
+
+MODULE_AUTHOR("Funs Kessen <funs@barred.org>");
+MODULE_DESCRIPTION("vsl3 driver, you know, for vsl3 devices");
+MODULE_INFO(supported, "external");

--- a/root/usr/src/iomemory-vsl4-4.3.7/mod.c
+++ b/root/usr/src/iomemory-vsl4-4.3.7/mod.c
@@ -1,5 +1,5 @@
 #include <linux/module.h>
 
 MODULE_AUTHOR("Funs Kessen <funs@barred.org>");
-MODULE_DESCRIPTION("vsl3 driver, you know, for vsl3 devices");
+MODULE_DESCRIPTION("vsl4 driver, you know, for vsl4 devices");
 MODULE_INFO(supported, "external");

--- a/root/usr/src/iomemory-vsl4-4.3.7/objtool_wrapper
+++ b/root/usr/src/iomemory-vsl4-4.3.7/objtool_wrapper
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-KERNEL_BUILD="/usr/src/kernels/6.15.4-200.fc42.x86_64"
 KERNEL_BUILD=$objtree
 [ -z "$KERNEL_BUILD" ] && echo "we need KERNEL_BUILD set: $KERNEL_BUILD" && exit 1
 objtool="$KERNEL_BUILD/tools/objtool/objtool"

--- a/root/usr/src/iomemory-vsl4-4.3.7/objtool_wrapper
+++ b/root/usr/src/iomemory-vsl4-4.3.7/objtool_wrapper
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+KERNEL_BUILD="/usr/src/kernels/6.15.4-200.fc42.x86_64"
+KERNEL_BUILD=$objtree
+[ -z "$KERNEL_BUILD" ] && echo "we need KERNEL_BUILD set: $KERNEL_BUILD" && exit 1
+objtool="$KERNEL_BUILD/tools/objtool/objtool"
+
+args=$(echo "$*" | sed s/--werror//)
+if [ -z "$objtool" ]; then
+    echo "$(basename "$0"): No objtool?" 1>&2
+    exit 255;
+fi
+[ "$DEBUG" != "" ] && echo "Running objtool $objtool $args"
+$objtool --sec-address $args
+rc=$?
+[ "$DEBUG" != "" ] && echo "objtool returned $rc"
+exit 0
+


### PR DESCRIPTION
* objtool wrapper for 6.15, toolchain now sees warning as an error. Also add filtering for -werror in the future.
* added KFIOC_X_BLK_MQ_F_SHOULD_MERGE. BLK_MQ_F_SHOULD_MERGE  got removed and became the default in 6.14
* added ccflags-y to the Makefile, EXTRA_CFLAGS is deprecated in 6.15