### PR TITLE
7 kernel checks numa node_id and is not happy if it's not actually there

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 5), linux-headers | linux-headers-amd64, gcc, make,
 Standards-Version: 3.7.3
 Homepage: http://support.fusionio.com
 
-Package: iomemory-vsl4-5.3.0-45-generic
+Package: iomemory-vsl4-6.11.0-28-generic
 Architecture: amd64
 Provides: iomemory-vsl4,
           iomemory-vsl4-${fio-version},
@@ -17,7 +17,7 @@ Replaces: iodrive-driver, fio-driver, libvsl
 Description: Driver for SanDisk Fusion ioMemory devices
  Driver for SanDisk Fusion ioMemory devices
 
-Package: iomemory-vsl4-config-5.3.0-45-generic
+Package: iomemory-vsl4-config-6.11.0-28-generic
 Architecture: amd64
 Provides: iomemory-vsl4-config,
           iomemory-vsl4-config-${fio-version}
@@ -35,16 +35,16 @@ Conflicts: iomemory-vsl4-${fio-version}, iomemory-vsl4
 Description: Source to build driver for SanDisk Fusion ioMemory devices
  Source to build driver for SanDisk Fusion ioMemory devices
 
-Package: iomemory-vsl4-di-5.3.0-45-generic
+Package: iomemory-vsl4-di-6.11.0-28-generic
 Package-Type: udeb
 Architecture: amd64
 Depends:
-XB-Kernel-Version: 5.3.0-45-generic
+XB-Kernel-Version: 6.11.0-28-generic
 Section: debian-installer
 Description: Source to build driver for SanDisk Fusion ioMemory devices
  Source to build driver for SanDisk Fusion ioMemory devices
 
-Package: iomemory-vsl4-initrd-5.3.0-45-generic
+Package: iomemory-vsl4-initrd-6.11.0-28-generic
 Architecture: amd64
 Depends: iomemory-vsl4
 XB-Modaliases:

--- a/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
+++ b/root/usr/src/iomemory-vsl4-4.3.7/include/kblock_meta.h
@@ -25,11 +25,11 @@
 
 #if KFIOC_X_BLK_ALLOC_DISK_EXISTS
   #define BLK_ALLOC_QUEUE dp->gd->queue;
-  #define BLK_ALLOC_DISK blk_alloc_disk(FIO_NUM_MINORS);
+  #define BLK_ALLOC_DISK blk_alloc_disk(NUMA_NO_NODE);
   #define BLK_MQ_ALLOC_QUEUE blk_mq_init_queue(&disk->tag_set);
 #elif KFIOC_X_BLK_ALLOC_DISK_HAS_QUEUE_LIMITS
   #define BLK_ALLOC_QUEUE dp->gd->queue;
-  #define BLK_ALLOC_DISK blk_alloc_disk(NULL, FIO_NUM_MINORS);
+  #define BLK_ALLOC_DISK blk_alloc_disk(NULL, NUMA_NO_NODE);
   #define BLK_MQ_ALLOC_QUEUE blk_mq_alloc_queue(&disk->tag_set, NULL, NULL);
 #else /* KFIOC_X_BLK_ALLOC_DISK_EXISTS */
   #if KFIOC_X_HAS_MAKE_REQUEST_FN != 1


### PR DESCRIPTION
blk_alloc_disk always took the node_id. We incorrectly passed the value that alloc_disk required, my bad. Due to a change in Kernel 7 putting an invalid node_id behaves different and surfaces this mistake.

Thanks @alwilson